### PR TITLE
fix(ios): add React import to resolve RCTView in Expo SDK 54

### DIFF
--- a/ios/UniversalTooltipView.swift
+++ b/ios/UniversalTooltipView.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import React
 
 import Popovers
 import SwiftUI


### PR DESCRIPTION
## What was broken

Building against Expo SDK 54 fails to compile with:

```
cannot find type 'RCTView' in scope
```

at `ios/UniversalTooltipView.swift:80` and `:119`.

`UniversalTooltipView.swift` references `RCTView` but only imports `ExpoModulesCore`, `Popovers`, and `SwiftUI`. In earlier SDKs React's headers were reachable transitively; from SDK 54 they are not, so the symbol no longer resolves.

## The fix

Adds an explicit `import React` to `ios/UniversalTooltipView.swift`. One line, no behavioural change.

## Verification

This is the fix @cemck identified in #23 and confirmed working locally. I don't currently have an SDK 54 iOS build environment, so I have not independently verified it — @sethbuff and @rklf both reported hitting this issue and may be able to confirm.

Worth noting the example app is still pinned to Expo 50 / RN 0.73.4, so it can't reproduce this as-is. Upgrading the example is a larger piece of work and out of scope here.

Closes #23